### PR TITLE
Add inline type-able extension for `on`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## 1.0.1
+
+### New
+
+ - Added reified inline extension for `on` to allow typing the action's `Throwable` parameter
+ - Updated [`retrofit-rx-matcher README`](https://github.com/mgray88/kotlin-error-handler/tree/1.0.1/errorhandler-matchers)
+
 ## 1.0.0
 
 ### New

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download the [latest JAR](https://bintray.com/is-digital/kotlin-error-handler/ko
 <dependency>
   <groupId>isdigital.errorhandler</groupId>
   <artifactId>kotlin-error-handler</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <type>pom</type>
 </dependency>
 ```
@@ -19,7 +19,7 @@ Download the [latest JAR](https://bintray.com/is-digital/kotlin-error-handler/ko
 or Gradle:
 
 ```groovy
-implementation 'isdigital.errorhandler:kotlin-error-handler:1.0.0'
+implementation 'isdigital.errorhandler:kotlin-error-handler:1.0.1'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ try {
 ### Run blocks of code using ErrorHandler.runHandling
 
 ```kotlin
-ErrorHandler.runHandling { fetchNewMessages() }
+errorHandler.runHandling { fetchNewMessages() }
 ```
 
 ### Override defaults when needed
@@ -140,6 +140,27 @@ try {
         errorHandler.skipAlways()
     }
     .handle(ex)
+}
+```
+
+### Extension functions provide type safety and ease of initialization
+
+```kotlin
+// Initialize a local `ErrorHandler` lazily and add actions inline to keep logic in one location
+// Inherits defaults from `defaultErrorHandler` or the provided optional parent `ErrorHandler`
+private val errorHandler by errorHandler(optionalParent) {
+  on(404) { throwable, errorHandler ->
+    displayAlert("Not found!")
+  }
+  on("offline") { throwable, errorHandler ->
+    displayAlert("Network dead!")
+  }
+
+
+  // Add typed actions on specific exceptions with an extension function
+  on<StaleDataException> { exception, errorHandler ->
+    // exception is of type StaleDataException
+  } 
 }
 ```
 
@@ -183,6 +204,12 @@ ErrorHandler is __thread-safe__.
 * `bindClass(KClass<T>, MatcherFactory<T>)` Bind class _T_ to match errors through a matcher provided by _MatcherFactory_.
 
 * `clear()` Clear all registered _Actions_.
+
+### Convenience Extensions
+
+* `errorHandler(ErrorHandler?, (ErrorHandler.() -> Unit)?)` Lazy initializer keeps error handling logic in one place.
+
+* `on<T : Exception>((T, ErrorHandler) -> Unit)` Register a typed _Action_ to be executed if error is an instance of `T`.
 
 ### Execute
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'isdigital.errorhandler'
-version '1.0.0'
+version '1.0.1'
 
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
@@ -30,7 +30,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId 'isdigital.errorhandler'
             artifactId 'parent'
-            version '1.0.0'
+            version '1.0.1'
         }
     }
 

--- a/errorhandler-matchers/README.md
+++ b/errorhandler-matchers/README.md
@@ -9,7 +9,7 @@ In order to use them, provide an instance of your desired MatcherFactory when bu
 ### Retrofit-Rx-Matcher
 
 ```gradle
-compile 'com.workable:retrofit-rx-matcher:1.1.0'
+implementation 'isdigital.errorhandler:retrofit-rx-matcher:1.0.1'
 ```
 
 ```java
@@ -17,17 +17,17 @@ compile 'com.workable:retrofit-rx-matcher:1.1.0'
 ErrorHandler
   .create()
   .bind(400, RetrofitMatcherFactory.create())
-  .on(400, (throwable, errorHandler) -> showErrorMessage("what?"))
-  .handle(httpException);
+  .on(400) { throwable, errorHandler -> showErrorMessage("what?") }
+  .handle(httpException)
 
 // Or bind all integers to Retrofit errors
 
 ErrorHandler
   .create()
-  .bindClass(Range.class, RetrofitMatcherFactory.createRange())
-  .bindClass(Integer.class, RetrofitMatcherFactory.create())
-  .on(400, (throwable, errorHandler) -> showErrorMessage("what?"))
-  .on(Range.of(500, 599), (throwable, errorHandler) -> showErrorMessage("kaboom"))
-  .handle(httpException);
+  .bindClass(Range::class, RetrofitMatcherFactory.createRange())
+  .bindClass(Int::class, RetrofitMatcherFactory.create())
+  .on(400) { throwable, errorHandler -> showErrorMessage("what?") }
+  .on(Range.of(500, 599)) { throwable, errorHandler -> showErrorMessage("kaboom") }
+  .handle(httpException)
 
 ```

--- a/errorhandler-matchers/retrofit-rx-matcher/build.gradle
+++ b/errorhandler-matchers/retrofit-rx-matcher/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'isdigital.errorhandler'
-version '1.0.0'
+version '1.0.1'
 
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
@@ -55,7 +55,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId 'isdigital.errorhandler'
             artifactId 'retrofit-rx-matcher'
-            version '1.0.0'
+            version '1.0.1'
 
             from components.java
 
@@ -99,10 +99,10 @@ bintray {
         labels = ['kotlin', 'error handler', 'errors', 'android']
         publicDownloadNumbers = true
         version {
-            name = '1.0.0'
+            name = '1.0.1'
 
             desc = 'Error handling library for Android and Kotlin'
-            vcsTag = 'v1.0.0'
+            vcsTag = '1.0.1'
             gpg {
                 sign = true //Determines whether to GPG sign the files. The default is false
             }

--- a/errorhandler/build.gradle
+++ b/errorhandler/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'isdigital.errorhandler'
-version '1.0.0'
+version '1.0.1'
 
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
@@ -59,7 +59,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId 'isdigital.errorhandler'
             artifactId 'kotlin-error-handler'
-            version '1.0.0'
+            version '1.0.1'
 
             from components.java
 
@@ -103,10 +103,10 @@ bintray {
         labels = ['kotlin', 'error handler', 'errors', 'android']
         publicDownloadNumbers = true
         version {
-            name = '1.0.0'
+            name = '1.0.1'
 
             desc = 'Error handling library for Android and Kotlin'
-            vcsTag = '1.0.0'
+            vcsTag = '1.0.1'
             gpg {
                 sign = true //Determines whether to GPG sign the files. The default is false
             }

--- a/errorhandler/src/main/kotlin/isdigital/errorhandler/ErrorHandler.kt
+++ b/errorhandler/src/main/kotlin/isdigital/errorhandler/ErrorHandler.kt
@@ -499,6 +499,18 @@ class ErrorHandler private constructor() {
 }
 
 /**
+ * Wrapper around `[.on(KClass, Action)]` to allow action's `Throwable` parameter
+ * to be typed to the `Throwable` expected
+ */
+inline fun <reified T : Throwable> ErrorHandler.on(
+    noinline action: (T, ErrorHandler) -> Unit
+): ErrorHandler {
+    return on(T::class) { throwable, errorHandler ->
+        action(throwable as T, errorHandler)
+    }
+}
+
+/**
  * Lazy `ErrorHandler` initializer which delegates to a parent, or the `defaultErrorHandler`
  * if the parent is not supplied. Uses optional lambda function to add actions and bindings to
  * the new `ErrorHandler`


### PR DESCRIPTION
Allows you to handle exceptions in a more type-safe manner, ex:
```
ErrorHandler.defaultErrorHandler()
  .on<HttpException> { exception, errorHandler -> 
    // exception is of type HttpException
  }
```

- Update README
- Bump version